### PR TITLE
Fix null results and compare_miRNA_strands consistency

### DIFF
--- a/R/dual_strand_hairpin.R
+++ b/R/dual_strand_hairpin.R
@@ -93,6 +93,7 @@
   sRes$folded <- FALSE
   
   for (strand in strands) {
+    null_results <- FALSE
     strand_name <- switch(strand, "+" = "plus", "-" = "minus")
     
     chrom <- .get_chr(bam_obj, chrom_name, reg_start, reg_stop, strand = strand)
@@ -132,6 +133,7 @@
         "+" = 2
       )
       null_res <- .null_hp_res()[[null_res_idx]]
+      null_results <- TRUE
     }
     
     # calculate phasing signatures
@@ -205,8 +207,10 @@
     }
     
     # results for the ML table
-    if ("null_res" %in% names(sRes[[strand]])) {
-      sRes[[strand_name]]$res <- sRes[[strand_name]]$null_res
+    if (null_results) {
+      sRes$MFE <- null_res[[strand_name]]$MFE
+      sRes$perc_paired <- null_res[[strand_name]]$perc_paired
+      sRes[[strand_name]]$res <- null_res
     } else {
       res <- list(
         MFE = sRes$MFE,

--- a/R/miRNA.R
+++ b/R/miRNA.R
@@ -81,7 +81,7 @@ miRNA <- function(vars) {
     )
   )
   
-  .compare_miRNA_strands(calling_func = "miRNA")
+  .compare_miRNA_strands(vars$chrom_name, vars$reg_start, vars$reg_stop, calling_func = "miRNA")
   
   .inform_complete(mi_dir)
 }

--- a/R/null_hp_res.R
+++ b/R/null_hp_res.R
@@ -3,66 +3,41 @@
 # @return list
 
 .null_hp_res <- function() {
-  neg_results <- function() {
-    MFE <- 0
-    
+  null_results <- function() {
     dicer_tbl <- data.frame(
-      shift = c(seq(-4, 4)),
-      zscore = c(rep(NA, times = 9)))
+      shift = seq(-4, 4),
+      zscore = rep(0, times = 9),
+      ml_zscore = rep(-33, times = 9)
+    )
     
     phased_tbl <- data.frame(
-      phased_dist = c(seq(0, 50)),
-      phased_num = c(rep(0, times = 51)),
-      zscore = c(rep(NA, times = 51)))
-
-    minus_hp_phasedz <- -33
-    minus_hp_overhangz <- -33
+      dist = seq(0, 50),
+      phased_num = rep(0, times = 51),
+      zscore = rep(0, times = 51),
+      ml_zscore = rep(-33, times = 51)
+    )
     
     return(list(
-      minusMFE = MFE,
-      minus_hp_overhangz = minus_hp_overhangz,
-      minus_hp_phasedz = minus_hp_phasedz,
+      MFE = 0,
+      hp_overhangz = 0,
+      hp_overhang_mlz = -33,
+      hp_phasedz = 0,
+      hp_phased_mlz = -33,
+      phased_tbl.dist = phased_tbl$dist,
+      phased_tbl.phased_z = phased_tbl$zscore,
+      phased_tbl.phased_mlz = phased_tbl$ml_zscore,
       dicer_tbl.shift = dicer_tbl$shift,
       dicer_tbl.zscore = dicer_tbl$zscore,
-      phased_tbl.phased_z = phased_tbl$zscore,
-      phased_tbl.dist = phased_tbl$dist,
+      dicer_tbl.ml_zscore = dicer_tbl$ml_zscore,
       perc_paired = 0
     ))
   }
 
-
-
-  pos_results <- function() {
-    MFE <- 0
-    
-    dicer_tbl <- data.frame(
-      shift = c(seq(-4, 4)),
-      zscore = c(rep(NA, times = 9)))
-    
-    phased_tbl <- data.frame(
-      dist = c(seq(0, 50)),
-      phased_num = c(rep(0, times = 51)),
-      zscore = c(rep(NA, times = 51)))
-    
-    plus_hp_phasedz <- -33
-    plus_hp_overhangz <- -33
-    
-    return(list(
-      plusMFE = MFE,
-      plus_hp_overhangz = plus_hp_overhangz,
-      plus_hp_phasedz = plus_hp_phasedz,
-      dicer_tbl.shift = dicer_tbl$shift,
-      dicer_tbl.zscore = dicer_tbl$zscore,
-      phased_tbl.phased_z = phased_tbl$zscore,
-      phased_tbl.dist = phased_tbl$dist,
-      perc_paired = 0
-    ))
-  }
-
-  minus_res <- neg_results()
-  plus_res <- pos_results()
+  minus_res <- null_results()
+  plus_res <- null_results()
   
   return(list(
     minus_res = minus_res,
-    plus_res = plus_res))
+    plus_res = plus_res)
+  )
 }

--- a/R/run_all.R
+++ b/R/run_all.R
@@ -70,7 +70,7 @@ run_all <- function(vars) {
   )
   
   # Compare dicer zscores in miRNA_zscore files and write final miRNA_zscore.txt
-  .compare_miRNA_strands(calling_func = "all")
+  .compare_miRNA_strands(vars$chrom_name, vars$reg_start, vars$reg_stop, calling_func = "all")
   
   .inform_complete(all_dir)
 }


### PR DESCRIPTION
compare_miRNA_strands was not allowing for duplicate lines in the bed file. This is corrected by finding the matched region in the bedfile and using those indices to insert results into the same rows of the result data frame.