### PR TITLE
Fix Rcpp linking

### DIFF
--- a/R/MiSiPi.RNA-package.R
+++ b/R/MiSiPi.RNA-package.R
@@ -5,5 +5,7 @@
 "_PACKAGE"
 
 ## usethis namespace: start
+#' @importFrom Rcpp sourceCpp
+#' @useDynLib MiSiPi.RNA, .registration = TRUE
 ## usethis namespace: end
 NULL


### PR DESCRIPTION
Rcpp was not properly linking in linux. Simple change to correct that in the package file.